### PR TITLE
Add rubocop style check, clean up, file renames

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,8 @@
 AllCops:
   Exclude:
   - spec/**/*
+  - vendor/**/*
+  - '*.gemspec'
   DisabledByDefault: true
   StyleGuideBaseURL: https://ctx.sh/ruby-style-guide/
 
@@ -275,6 +277,7 @@ Style/MethodCallWithArgsParentheses:
   - printf
   Exclude:
   - Gemfile
+  - Rakefile
 
 Style/MethodDefParentheses:
   EnforcedStyle: require_parentheses

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,1050 @@
+AllCops:
+  Exclude:
+  - spec/**/*
+  DisabledByDefault: true
+  StyleGuideBaseURL: https://ctx.sh/ruby-style-guide/
+
+Lint/AssignmentInCondition:
+  Enabled: true
+
+Layout/AccessModifierIndentation:
+  EnforcedStyle: indent
+  SupportedStyles:
+  - outdent
+  - indent
+  IndentationWidth:
+
+Style/Alias:
+  EnforcedStyle: prefer_alias_method
+  SupportedStyles:
+  - prefer_alias
+  - prefer_alias_method
+
+Layout/AlignHash:
+  EnforcedHashRocketStyle: key
+  EnforcedColonStyle: key
+  EnforcedLastArgumentHashStyle: ignore_implicit
+  SupportedLastArgumentHashStyles:
+  - always_inspect
+  - always_ignore
+  - ignore_implicit
+  - ignore_explicit
+
+Layout/AlignParameters:
+  EnforcedStyle: with_fixed_indentation
+  SupportedStyles:
+  - with_first_parameter
+  - with_fixed_indentation
+  IndentationWidth:
+
+Style/AndOr:
+  EnforcedStyle: always
+  SupportedStyles:
+  - always
+  - conditionals
+
+Style/BarePercentLiterals:
+  EnforcedStyle: bare_percent
+  SupportedStyles:
+  - percent_q
+  - bare_percent
+
+Style/BlockDelimiters:
+  EnforcedStyle: line_count_based
+  SupportedStyles:
+  - line_count_based
+  - semantic
+  - braces_for_chaining
+  ProceduralMethods:
+  - benchmark
+  - bm
+  - bmbm
+  - create
+  - each_with_object
+  - measure
+  - new
+  - realtime
+  - tap
+  - with_object
+  FunctionalMethods:
+  - let
+  - let!
+  - subject
+  - watch
+  IgnoredMethods:
+  - lambda
+  - proc
+  - it
+
+Style/BracesAroundHashParameters:
+  EnforcedStyle: no_braces
+  SupportedStyles:
+  - braces
+  - no_braces
+  - context_dependent
+
+Layout/CaseIndentation:
+  EnforcedStyle: end
+  SupportedStyles:
+  - case
+  - end
+  IndentOneStep: false
+  IndentationWidth:
+
+Style/ClassAndModuleChildren:
+  EnforcedStyle: nested
+  SupportedStyles:
+  - nested
+  - compact
+
+Style/ClassCheck:
+  EnforcedStyle: is_a?
+  SupportedStyles:
+  - is_a?
+  - kind_of?
+
+Style/CommandLiteral:
+  EnforcedStyle: percent_x
+  SupportedStyles:
+  - backticks
+  - percent_x
+  - mixed
+  AllowInnerBackticks: false
+
+Style/CommentAnnotation:
+  Keywords:
+  - TODO
+  - FIXME
+  - OPTIMIZE
+  - HACK
+  - REVIEW
+
+Style/ConditionalAssignment:
+  EnforcedStyle: assign_to_condition
+  SupportedStyles:
+  - assign_to_condition
+  - assign_inside_condition
+  SingleLineConditionsOnly: true
+
+Layout/DotPosition:
+  EnforcedStyle: leading
+  SupportedStyles:
+  - leading
+  - trailing
+
+Style/EmptyElse:
+  EnforcedStyle: both
+  SupportedStyles:
+  - empty
+  - nil
+  - both
+
+Layout/EmptyLineBetweenDefs:
+  AllowAdjacentOneLineDefs: false
+
+Layout/EmptyLinesAroundBlockBody:
+  EnforcedStyle: no_empty_lines
+  SupportedStyles:
+  - empty_lines
+  - no_empty_lines
+
+Layout/EmptyLinesAroundClassBody:
+  EnforcedStyle: no_empty_lines
+  SupportedStyles:
+  - empty_lines
+  - empty_lines_except_namespace
+  - no_empty_lines
+
+Layout/EmptyLinesAroundModuleBody:
+  EnforcedStyle: no_empty_lines
+  SupportedStyles:
+  - empty_lines
+  - empty_lines_except_namespace
+  - no_empty_lines
+
+Layout/ExtraSpacing:
+  AllowForAlignment: true
+  ForceEqualSignAlignment: false
+
+Naming/FileName:
+  Exclude: []
+  ExpectMatchingDefinition: false
+  Regex:
+  IgnoreExecutableScripts: true
+
+Layout/IndentFirstArgument:
+  EnforcedStyle: consistent
+  SupportedStyles:
+  - consistent
+  - special_for_inner_method_call
+  - special_for_inner_method_call_in_parentheses
+  IndentationWidth:
+
+Style/For:
+  EnforcedStyle: each
+  SupportedStyles:
+  - for
+  - each
+
+Style/FormatString:
+  EnforcedStyle: format
+  SupportedStyles:
+  - format
+  - sprintf
+  - percent
+
+Style/FrozenStringLiteralComment:
+  Details: >-
+    Add `# frozen_string_literal: true` to the top of the file. Frozen string
+    literals will become the default in a future Ruby version, and we want to
+    make sure we're ready.
+  EnforcedStyle: always
+  SupportedStyles:
+    - always
+    - never
+
+Style/GlobalVars:
+  AllowedVariables: []
+
+Style/HashSyntax:
+  EnforcedStyle: ruby19
+  SupportedStyles:
+  - ruby19
+  - hash_rockets
+  - no_mixed_keys
+  - ruby19_no_mixed_keys
+  UseHashRocketsWithSymbolValues: false
+  PreferHashRocketsForNonAlnumEndingSymbols: false
+
+Layout/IndentationConsistency:
+  EnforcedStyle: normal
+  SupportedStyles:
+  - normal
+  - rails
+
+Layout/IndentationWidth:
+  Width: 2
+
+Layout/IndentFirstArrayElement:
+  EnforcedStyle: consistent
+  SupportedStyles:
+  - special_inside_parentheses
+  - consistent
+  - align_brackets
+  IndentationWidth:
+
+Layout/IndentAssignment:
+  IndentationWidth:
+
+Layout/IndentFirstHashElement:
+  EnforcedStyle: consistent
+  SupportedStyles:
+  - special_inside_parentheses
+  - consistent
+  - align_braces
+  IndentationWidth:
+
+Style/LambdaCall:
+  EnforcedStyle: call
+  SupportedStyles:
+  - call
+  - braces
+
+Style/Next:
+  EnforcedStyle: skip_modifier_ifs
+  MinBodyLength: 3
+  SupportedStyles:
+  - skip_modifier_ifs
+  - always
+
+Style/NonNilCheck:
+  IncludeSemanticChanges: false
+
+Style/MethodCallWithArgsParentheses:
+  Enabled: true
+  IgnoreMacros: true
+  IgnoredMethods:
+  - require
+  - require_relative
+  - require_dependency
+  - yield
+  - raise
+  - puts
+  - exit
+  - print
+  - printf
+  Exclude:
+  - Gemfile
+
+Style/MethodDefParentheses:
+  EnforcedStyle: require_parentheses
+  SupportedStyles:
+  - require_parentheses
+  - require_no_parentheses
+  - require_no_parentheses_except_multiline
+
+Naming/MethodName:
+  EnforcedStyle: snake_case
+  SupportedStyles:
+  - snake_case
+  - camelCase
+
+Layout/MultilineArrayBraceLayout:
+  EnforcedStyle: symmetrical
+  SupportedStyles:
+  - symmetrical
+  - new_line
+  - same_line
+
+Layout/MultilineHashBraceLayout:
+  EnforcedStyle: symmetrical
+  SupportedStyles:
+  - symmetrical
+  - new_line
+  - same_line
+
+Layout/MultilineMethodCallBraceLayout:
+  EnforcedStyle: symmetrical
+  SupportedStyles:
+  - symmetrical
+  - new_line
+  - same_line
+
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+  SupportedStyles:
+  - aligned
+  - indented
+  - indented_relative_to_receiver
+  IndentationWidth: 2
+
+Layout/MultilineMethodDefinitionBraceLayout:
+  EnforcedStyle: symmetrical
+  SupportedStyles:
+  - symmetrical
+  - new_line
+  - same_line
+
+Style/NumericLiteralPrefix:
+  EnforcedOctalStyle: zero_only
+  SupportedOctalStyles:
+  - zero_with_o
+  - zero_only
+
+Style/ParenthesesAroundCondition:
+  AllowSafeAssignment: true
+
+Style/PercentQLiterals:
+  EnforcedStyle: lower_case_q
+  SupportedStyles:
+  - lower_case_q
+  - upper_case_q
+
+Naming/PredicateName:
+  NamePrefix:
+  - is_
+  NamePrefixBlacklist:
+  - is_
+  NameWhitelist:
+  - is_a?
+  Exclude:
+  - 'spec/**/*'
+
+Style/PreferredHashMethods:
+  EnforcedStyle: short
+  SupportedStyles:
+  - short
+  - verbose
+
+Style/RaiseArgs:
+  EnforcedStyle: exploded
+  SupportedStyles:
+  - compact
+  - exploded
+
+Style/RedundantReturn:
+  AllowMultipleReturnValues: false
+
+Style/RegexpLiteral:
+  EnforcedStyle: mixed
+  SupportedStyles:
+  - slashes
+  - percent_r
+  - mixed
+  AllowInnerSlashes: false
+
+Style/SafeNavigation:
+  ConvertCodeThatCanStartToReturnNil: false
+  Enabled: true
+
+Lint/SafeNavigationChain:
+  Enabled: true
+
+Style/Semicolon:
+  AllowAsExpressionSeparator: false
+
+Style/SignalException:
+  EnforcedStyle: only_raise
+  SupportedStyles:
+  - only_raise
+  - only_fail
+  - semantic
+
+Style/SingleLineMethods:
+  AllowIfMethodIsEmpty: true
+
+Layout/SpaceBeforeFirstArg:
+  AllowForAlignment: true
+
+Style/SpecialGlobalVars:
+  EnforcedStyle: use_english_names
+  SupportedStyles:
+  - use_perl_names
+  - use_english_names
+
+Style/StabbyLambdaParentheses:
+  EnforcedStyle: require_parentheses
+  SupportedStyles:
+  - require_parentheses
+  - require_no_parentheses
+
+Style/StringLiteralsInInterpolation:
+  EnforcedStyle: single_quotes
+  SupportedStyles:
+  - single_quotes
+  - double_quotes
+
+Layout/SpaceAroundBlockParameters:
+  EnforcedStyleInsidePipes: no_space
+  SupportedStylesInsidePipes:
+  - space
+  - no_space
+
+Layout/SpaceAroundEqualsInParameterDefault:
+  EnforcedStyle: space
+  SupportedStyles:
+  - space
+  - no_space
+
+Layout/SpaceAroundOperators:
+  AllowForAlignment: true
+
+Layout/SpaceBeforeBlockBraces:
+  EnforcedStyle: space
+  EnforcedStyleForEmptyBraces: space
+  SupportedStyles:
+  - space
+  - no_space
+
+Layout/SpaceInsideBlockBraces:
+  EnforcedStyle: space
+  SupportedStyles:
+  - space
+  - no_space
+  EnforcedStyleForEmptyBraces: no_space
+  SpaceBeforeBlockParameters: true
+
+Layout/SpaceInsideHashLiteralBraces:
+  EnforcedStyle: space
+  EnforcedStyleForEmptyBraces: no_space
+  SupportedStyles:
+  - space
+  - no_space
+  - compact
+
+Layout/SpaceInsideStringInterpolation:
+  EnforcedStyle: no_space
+  SupportedStyles:
+  - space
+  - no_space
+
+Style/SymbolProc:
+  IgnoredMethods:
+  - respond_to
+  - define_method
+
+Style/TernaryParentheses:
+  EnforcedStyle: require_no_parentheses
+  SupportedStyles:
+  - require_parentheses
+  - require_no_parentheses
+  AllowSafeAssignment: true
+
+Layout/TrailingBlankLines:
+  EnforcedStyle: final_newline
+  SupportedStyles:
+  - final_newline
+  - final_blank_line
+
+Style/TrivialAccessors:
+  ExactNameMatch: true
+  AllowPredicates: true
+  AllowDSLWriters: false
+  IgnoreClassMethods: false
+  Whitelist:
+  - to_ary
+  - to_a
+  - to_c
+  - to_enum
+  - to_h
+  - to_hash
+  - to_i
+  - to_int
+  - to_io
+  - to_open
+  - to_path
+  - to_proc
+  - to_r
+  - to_regexp
+  - to_str
+  - to_s
+  - to_sym
+
+Naming/VariableName:
+  EnforcedStyle: snake_case
+  SupportedStyles:
+  - snake_case
+  - camelCase
+
+Style/WhileUntilModifier:
+  Enabled: true
+
+Metrics/BlockNesting:
+  Max: 3
+
+Metrics/LineLength:
+  Max: 160
+  AllowHeredoc: true
+  AllowURI: true
+  URISchemes:
+  - http
+  - https
+  IgnoreCopDirectives: false
+  IgnoredPatterns:
+  - '\A\s*(remote_)?test(_\w+)?\s.*(do|->)(\s|\Z)'
+
+Metrics/ParameterLists:
+  Max: 5
+  CountKeywordArgs: false
+
+Layout/BlockAlignment:
+  EnforcedStyleAlignWith: either
+  SupportedStylesAlignWith:
+  - either
+  - start_of_block
+  - start_of_line
+
+Layout/EndAlignment:
+  EnforcedStyleAlignWith: variable
+  SupportedStylesAlignWith:
+  - keyword
+  - variable
+  - start_of_line
+
+Layout/DefEndAlignment:
+  EnforcedStyleAlignWith: start_of_line
+  SupportedStylesAlignWith:
+  - start_of_line
+  - def
+
+Lint/InheritException:
+  EnforcedStyle: runtime_error
+  SupportedStyles:
+  - runtime_error
+  - standard_error
+
+Lint/UnusedBlockArgument:
+  IgnoreEmptyBlocks: true
+  AllowUnusedKeywordArguments: false
+
+Lint/UnusedMethodArgument:
+  AllowUnusedKeywordArguments: false
+  IgnoreEmptyMethods: true
+
+Naming/AccessorMethodName:
+  Enabled: true
+
+Layout/AlignArray:
+  Enabled: true
+
+Style/ArrayJoin:
+  Enabled: true
+
+Naming/AsciiIdentifiers:
+  Enabled: true
+
+Style/Attr:
+  Enabled: true
+
+Style/BeginBlock:
+  Enabled: true
+
+Style/BlockComments:
+  Enabled: true
+
+Layout/BlockEndNewline:
+  Enabled: true
+
+Style/CaseEquality:
+  Enabled: true
+
+Style/CharacterLiteral:
+  Enabled: true
+
+Naming/ClassAndModuleCamelCase:
+  Enabled: true
+
+Style/ClassMethods:
+  Enabled: true
+
+Style/ClassVars:
+  Enabled: true
+
+Layout/ClosingParenthesisIndentation:
+  Enabled: true
+
+Style/ColonMethodCall:
+  Enabled: true
+
+Layout/CommentIndentation:
+  Enabled: true
+
+Naming/ConstantName:
+  Enabled: true
+
+Style/DateTime:
+  Enabled: true
+
+Style/DefWithParentheses:
+  Enabled: true
+
+Style/EachForSimpleLoop:
+  Enabled: true
+
+Style/EachWithObject:
+  Enabled: true
+
+Layout/ElseAlignment:
+  Enabled: true
+
+Style/EmptyCaseCondition:
+  Enabled: true
+
+Layout/EmptyLines:
+  Enabled: true
+
+Layout/EmptyLinesAroundAccessModifier:
+  Enabled: true
+
+Layout/EmptyLinesAroundMethodBody:
+  Enabled: true
+
+Style/EmptyLiteral:
+  Enabled: true
+
+Style/EndBlock:
+  Enabled: true
+
+Layout/EndOfLine:
+  Enabled: true
+
+Style/EvenOdd:
+  Enabled: true
+
+Layout/InitialIndentation:
+  Enabled: true
+
+Lint/FlipFlop:
+  Enabled: true
+
+Style/IfInsideElse:
+  Enabled: true
+
+Style/IfUnlessModifierOfIfUnless:
+  Enabled: true
+
+Style/IfWithSemicolon:
+  Enabled: true
+
+Style/IdenticalConditionalBranches:
+  Enabled: true
+
+Style/InfiniteLoop:
+  Enabled: true
+
+Layout/LeadingCommentSpace:
+  Enabled: true
+
+Style/LineEndConcatenation:
+  Enabled: true
+
+Style/MethodCallWithoutArgsParentheses:
+  Enabled: true
+
+Style/MethodMissingSuper:
+  Enabled: true
+
+Style/MissingRespondToMissing:
+  Enabled: true
+
+Layout/MultilineBlockLayout:
+  Enabled: true
+
+Style/MultilineIfThen:
+  Enabled: true
+
+Style/MultilineMemoization:
+  Enabled: true
+
+Style/MultilineTernaryOperator:
+  Enabled: true
+
+Style/NegatedIf:
+  Enabled: true
+
+Style/NegatedWhile:
+  Enabled: true
+
+Style/NestedModifier:
+  Enabled: true
+
+Style/NestedParenthesizedCalls:
+  Enabled: true
+
+Style/NestedTernaryOperator:
+  Enabled: true
+
+Style/NilComparison:
+  Enabled: true
+
+Style/Not:
+  Enabled: true
+
+Style/OneLineConditional:
+  Enabled: true
+
+Naming/BinaryOperatorParameterName:
+  Enabled: true
+
+Style/OptionalArguments:
+  Enabled: true
+
+Style/ParallelAssignment:
+  Enabled: true
+
+Style/PerlBackrefs:
+  Enabled: true
+
+Style/Proc:
+  Enabled: true
+
+Style/RedundantBegin:
+  Enabled: true
+
+Style/RedundantException:
+  Enabled: true
+
+Style/RedundantFreeze:
+  Enabled: true
+
+Style/RedundantParentheses:
+  Enabled: true
+
+Style/RedundantSelf:
+  Enabled: true
+
+Style/RedundantSortBy:
+  Enabled: true
+
+Layout/RescueEnsureAlignment:
+  Enabled: true
+
+Style/RescueModifier:
+  Enabled: true
+
+Style/Sample:
+  Enabled: true
+
+Style/SelfAssignment:
+  Enabled: true
+
+Layout/SpaceAfterColon:
+  Enabled: true
+
+Layout/SpaceAfterComma:
+  Enabled: true
+
+Layout/SpaceAfterMethodName:
+  Enabled: true
+
+Layout/SpaceAfterNot:
+  Enabled: true
+
+Layout/SpaceAfterSemicolon:
+  Enabled: true
+
+Layout/SpaceBeforeComma:
+  Enabled: true
+
+Layout/SpaceBeforeComment:
+  Enabled: true
+
+Layout/SpaceBeforeSemicolon:
+  Enabled: true
+
+Layout/SpaceAroundKeyword:
+  Enabled: true
+
+Layout/SpaceInsideArrayPercentLiteral:
+  Enabled: true
+
+Layout/SpaceInsidePercentLiteralDelimiters:
+  Enabled: true
+
+Layout/SpaceInsideArrayLiteralBrackets:
+  Enabled: true
+
+Layout/SpaceInsideParens:
+  Enabled: true
+
+Layout/SpaceInsideRangeLiteral:
+  Enabled: true
+
+Style/SymbolLiteral:
+  Enabled: true
+
+Layout/Tab:
+  Enabled: true
+
+Layout/TrailingWhitespace:
+  Enabled: true
+
+Style/UnlessElse:
+  Enabled: true
+
+Style/UnneededCapitalW:
+  Enabled: true
+
+Style/UnneededInterpolation:
+  Enabled: true
+
+Style/UnneededPercentQ:
+  Enabled: true
+
+Style/VariableInterpolation:
+  Enabled: true
+
+Style/WhenThen:
+  Enabled: true
+
+Style/WhileUntilDo:
+  Enabled: true
+
+Style/ZeroLengthPredicate:
+  Enabled: true
+
+Layout/IndentHeredoc:
+  EnforcedStyle: squiggly
+
+Lint/AmbiguousOperator:
+  Enabled: true
+
+Lint/AmbiguousRegexpLiteral:
+  Enabled: true
+
+Lint/CircularArgumentReference:
+  Enabled: true
+
+Layout/ConditionPosition:
+  Enabled: true
+
+Lint/Debugger:
+  Enabled: true
+
+Lint/DeprecatedClassMethods:
+  Enabled: true
+
+Lint/DuplicateMethods:
+  Enabled: true
+
+Lint/DuplicatedKey:
+  Enabled: true
+
+Lint/EachWithObjectArgument:
+  Enabled: true
+
+Lint/ElseLayout:
+  Enabled: true
+
+Lint/EmptyEnsure:
+  Enabled: true
+
+Lint/EmptyInterpolation:
+  Enabled: true
+
+Lint/EndInMethod:
+  Enabled: true
+
+Lint/EnsureReturn:
+  Enabled: true
+
+Lint/FloatOutOfRange:
+  Enabled: true
+
+Lint/FormatParameterMismatch:
+  Enabled: true
+
+Lint/HandleExceptions:
+  Enabled: true
+
+Lint/ImplicitStringConcatenation:
+  Description: Checks for adjacent string literals on the same line, which could
+    better be represented as a single string literal.
+
+Lint/IneffectiveAccessModifier:
+  Description: Checks for attempts to use `private` or `protected` to set the visibility
+    of a class method, which does not work.
+
+Lint/LiteralAsCondition:
+  Enabled: true
+
+Lint/LiteralInInterpolation:
+  Enabled: true
+
+Lint/Loop:
+  Description: Use Kernel#loop with break rather than begin/end/until or begin/end/while
+    for post-loop tests.
+
+Lint/NestedMethodDefinition:
+  Enabled: true
+
+Lint/NextWithoutAccumulator:
+  Description: Do not omit the accumulator when calling `next` in a `reduce`/`inject`
+    block.
+
+Lint/NonLocalExitFromIterator:
+  Enabled: true
+
+Lint/ParenthesesAsGroupedExpression:
+  Enabled: true
+
+Lint/PercentStringArray:
+  Enabled: true
+
+Lint/PercentSymbolArray:
+  Enabled: true
+
+Lint/RandOne:
+  Description: Checks for `rand(1)` calls. Such calls always return `0` and most
+    likely a mistake.
+
+Lint/RequireParentheses:
+  Enabled: true
+
+Lint/RescueException:
+  Enabled: true
+
+Lint/ShadowedException:
+  Enabled: true
+
+Lint/ShadowingOuterLocalVariable:
+  Enabled: true
+
+Lint/StringConversionInInterpolation:
+  Enabled: true
+
+Lint/UnderscorePrefixedVariableName:
+  Enabled: true
+
+Lint/UnifiedInteger:
+  Enabled: true
+
+Lint/UnneededCopDisableDirective:
+  Enabled: true
+
+Lint/UnneededCopEnableDirective:
+  Enabled: true
+
+Lint/UnneededSplatExpansion:
+  Enabled: true
+
+Lint/UnreachableCode:
+  Enabled: true
+
+Lint/UselessAccessModifier:
+  ContextCreatingMethods: []
+
+Lint/UselessAssignment:
+  Enabled: true
+
+Lint/UselessComparison:
+  Enabled: true
+
+Lint/UselessElseWithoutRescue:
+  Enabled: true
+
+Lint/UselessSetterCall:
+  Enabled: true
+
+Lint/Void:
+  Enabled: true
+
+Rails/ApplicationRecord:
+  Enabled: true
+
+Rails/DelegateAllowBlank:
+  Enabled: true
+
+Rails/HttpPositionalArguments:
+  Include:
+  - spec/**/*
+  - test/**/*
+
+Rails/InverseOf:
+  Enabled: true
+
+Rails/OutputSafety:
+  Enabled: true
+
+Rails/PluralizationGrammar:
+  Enabled: true
+
+Security/Eval:
+  Enabled: true
+
+Security/JSONLoad:
+  Enabled: true
+
+Security/Open:
+  Enabled: true
+
+Lint/BigDecimalNew:
+  Enabled: true
+
+Style/Strip:
+  Enabled: true
+
+Style/TrailingBodyOnClass:
+  Enabled: true
+
+Style/TrailingBodyOnModule:
+  Enabled: true
+
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: comma
+  Enabled: true
+
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: comma
+  Enabled: true
+
+Layout/SpaceInsideReferenceBrackets:
+  EnforcedStyle: no_space
+  EnforcedStyleForEmptyBrackets: no_space
+  Enabled: true
+
+Style/ModuleFunction:
+  EnforcedStyle: extend_self
+
+Lint/OrderedMagicComments:
+  Enabled: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ cache: bundler
 sudo: false
 script:
   - bundle exec rake
+  - bundle exec rubocop
 rvm:
-- 1.9.3
-- 2.0.0
-- 2.1.6
-- 2.2.2
+- 2.4.5
+- 2.5.3
+- 2.6.1

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,2 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 require 'rake/clean'

--- a/Rakefile
+++ b/Rakefile
@@ -2,18 +2,16 @@ require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 require 'rake/clean'
 
-
 CLEAN << 'reports'
 CLOBBER << FileList['kafkat*.gem']
 
 desc 'Run all specs'
 RSpec::Core::RakeTask.new :spec do |t|
   t.pattern = ['spec/**/*_spec.rb']
-  t.rspec_opts = %w{--order random --format documentation --color --format html --out reports/specs.html}
-  t.rspec_opts << "--backtrace" if ENV['backtrace']
+  t.rspec_opts = %w(--order random --format documentation --color --format html --out reports/specs.html)
+  t.rspec_opts << '--backtrace' if ENV['backtrace']
   t.verbose = true
 end
-
 
 desc 'Run all specs and generate spec and coverage reports'
 task :coverage do
@@ -21,5 +19,5 @@ task :coverage do
   Rake::Task['spec'].invoke
 end
 
-task :test => :spec
-task :default => :coverage
+task test: :spec
+task default: :coverage

--- a/_kafkat
+++ b/_kafkat
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 # Run kafkat from source, specifically for testing stuff without doing a rake install.
 

--- a/_kafkat
+++ b/_kafkat
@@ -10,7 +10,7 @@ spec = Gem::Specification.load(File.join(File.dirname(__FILE__), 'kafkat.gemspec
 
 # To avoid a warning about the version_requirements deprecation, we use this method inline.
 def version_required(gem_def)
-  return Gem::Dependency.instance_methods.map(&:to_sym).include?(:requirement) ? gem_def.requirement : gem_def.version_requirements
+  Gem::Dependency.instance_methods.map(&:to_sym).include?(:requirement) ? gem_def.requirement : gem_def.version_requirements
 end
 spec.dependencies.each do |dep|
   gem dep.name, version_required(dep) if dep.type == :runtime

--- a/bin/kafkat
+++ b/bin/kafkat
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
-$:.push File.expand_path('../../lib', __FILE__)
+$LOAD_PATH.push File.expand_path('../lib', __dir__)
 require 'kafkat'
 Kafkat::CLI.run!

--- a/bin/kafkat
+++ b/bin/kafkat
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
-$LOAD_PATH.push File.expand_path('../lib', __dir__)
+# frozen_string_literal: true
+
+$LOAD_PATH.push(File.expand_path('../lib', __dir__))
 require 'kafkat'
 Kafkat::CLI.run!

--- a/kafkat.gemspec
+++ b/kafkat.gemspec
@@ -1,15 +1,14 @@
-# encoding: utf-8
-$:.push File.expand_path('../lib', __FILE__)
+$LOAD_PATH.push File.expand_path('lib', __dir__)
 require 'kafkat/version'
 
 Gem::Specification.new do |s|
   s.name         = 'kafkat'
   s.version      = Kafkat::VERSION
   s.platform     = Gem::Platform::RUBY
-  s.authors      = ["Nelson Gauthier"]
+  s.authors      = ['Nelson Gauthier']
   s.email        = ['nelson@airbnb.com']
   s.homepage     = 'https://github.com/airbnb/kafkat'
-  s.summary      = "Simplified command-line administration for Kafka brokers"
+  s.summary      = 'Simplified command-line administration for Kafka brokers'
   s.description  = s.summary
   s.license      = 'Apache-v2'
 
@@ -18,17 +17,19 @@ Gem::Specification.new do |s|
   s.test_files   = s.files.grep(%r{^(test|spec|features)/})
   s.require_path = 'lib'
 
-  s.add_runtime_dependency 'zk', '~> 1.9', '>= 1.9.4'
-  s.add_runtime_dependency 'optimist', '~> 3.0'
-  s.add_runtime_dependency 'highline', '~> 1.6', '>= 1.6.21'
-  s.add_runtime_dependency 'retryable', '~> 1.3', '>= 1.3.5'
   s.add_runtime_dependency 'colored', '~> 1.2'
+  s.add_runtime_dependency 'highline', '~> 1.6', '>= 1.6.21'
   s.add_runtime_dependency 'json', '~> 1.8'
+  s.add_runtime_dependency 'optimist', '~> 3.0'
+  s.add_runtime_dependency 'retryable', '~> 1.3', '>= 1.3.5'
+  s.add_runtime_dependency 'zk', '~> 1.9', '>= 1.9.4'
 
   s.add_development_dependency 'activesupport', '>= 2', '< 5'
+  s.add_development_dependency 'factory_bot', '~> 5.0.0'
   s.add_development_dependency 'rake', '<= 10.5.0'
-  s.add_development_dependency 'simplecov', '~> 0.11.0'
   s.add_development_dependency 'rspec', '~> 3.2.0'
   s.add_development_dependency 'rspec-collection_matchers', '~> 1.1.0'
-  s.add_development_dependency 'factory_girl', '~> 4.5.0'
+  s.add_development_dependency 'rubocop', '~> 0.70.0'
+  s.add_development_dependency 'rubocop-rspec', '~> 1.33.0'
+  s.add_development_dependency 'simplecov', '~> 0.16.1'
 end

--- a/lib/kafkat.rb
+++ b/lib/kafkat.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'zk'
 require 'json'
 require 'optimist'

--- a/lib/kafkat/cli.rb
+++ b/lib/kafkat/cli.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafkat
   class CLI
     attr_reader :config

--- a/lib/kafkat/cli.rb
+++ b/lib/kafkat/cli.rb
@@ -43,9 +43,10 @@ module Kafkat
       print "\nHere's a list of supported commands:\n\n"
       Command.all.values.sort_by(&:command_name).each do |klass|
         klass.usages.each do |usage|
-          format, description = usage[0], usage[1]
+          format = usage[0]
+          description = usage[1]
           padding_length = 68 - format.length
-          padding = " " * padding_length unless padding_length < 0
+          padding = ' ' * padding_length unless padding_length.negative?
           print "  #{format}#{padding}#{description}\n"
         end
       end

--- a/lib/kafkat/cluster.rb
+++ b/lib/kafkat/cluster.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'kafkat/cluster/broker'
 require 'kafkat/cluster/topic'
 require 'kafkat/cluster/partition'

--- a/lib/kafkat/cluster/assignment.rb
+++ b/lib/kafkat/cluster/assignment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafkat
   Assignment = Struct.new(:topic_name, :partition_id, :replicas)
 end

--- a/lib/kafkat/cluster/assignment.rb
+++ b/lib/kafkat/cluster/assignment.rb
@@ -1,4 +1,3 @@
 module Kafkat
-  class Assignment < Struct.new(:topic_name, :partition_id, :replicas)
-  end
+  Assignment = Struct.new(:topic_name, :partition_id, :replicas)
 end

--- a/lib/kafkat/cluster/broker.rb
+++ b/lib/kafkat/cluster/broker.rb
@@ -1,4 +1,3 @@
 module Kafkat
-  class Broker < Struct.new(:id, :host, :port)
-  end
+  Broker = Struct.new(:id, :host, :port)
 end

--- a/lib/kafkat/cluster/broker.rb
+++ b/lib/kafkat/cluster/broker.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafkat
   Broker = Struct.new(:id, :host, :port)
 end

--- a/lib/kafkat/cluster/partition.rb
+++ b/lib/kafkat/cluster/partition.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafkat
   Partition = Struct.new(:topic_name, :id, :replicas, :leader, :isr) do
     def has_leader?(brokers)

--- a/lib/kafkat/cluster/partition.rb
+++ b/lib/kafkat/cluster/partition.rb
@@ -1,5 +1,5 @@
 module Kafkat
-  class Partition < Struct.new(:topic_name, :id, :replicas, :leader, :isr)
+  Partition = Struct.new(:topic_name, :id, :replicas, :leader, :isr) do
     def has_leader?(brokers)
       leader && leader != -1 && brokers.include?(leader)
     end

--- a/lib/kafkat/cluster/topic.rb
+++ b/lib/kafkat/cluster/topic.rb
@@ -1,4 +1,3 @@
 module Kafkat
-  class Topic < Struct.new(:name, :partitions)
-  end
+  Topic = Struct.new(:name, :partitions)
 end

--- a/lib/kafkat/cluster/topic.rb
+++ b/lib/kafkat/cluster/topic.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafkat
   Topic = Struct.new(:name, :partitions)
 end

--- a/lib/kafkat/command.rb
+++ b/lib/kafkat/command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafkat
   module Command
     class NotFoundError < StandardError; end

--- a/lib/kafkat/command.rb
+++ b/lib/kafkat/command.rb
@@ -8,7 +8,8 @@ module Kafkat
 
     def self.get(name)
       klass = all[name.downcase]
-      raise NotFoundError if !klass
+      raise NotFoundError unless klass
+
       klass
     end
 
@@ -66,5 +67,5 @@ module Kafkat
 end
 
 # Require all of the commands.
-command_glob = File.expand_path("../command/*.rb", __FILE__)
+command_glob = File.expand_path('command/*.rb', __dir__)
 Dir[command_glob].each { |f| require f }

--- a/lib/kafkat/command/brokers.rb
+++ b/lib/kafkat/command/brokers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Kafkat
   module Command
     class Brokers < Base
@@ -7,9 +8,9 @@ module Kafkat
             'Print available brokers from Zookeeper.'
 
       def run
-        bs = zookeeper.get_brokers
+        bs = zookeeper.brokers
         print_broker_header
-        bs.each { |id, b| print_broker(b) }
+        bs.each { |_, b| print_broker(b) }
       end
     end
   end

--- a/lib/kafkat/command/clean_indexes.rb
+++ b/lib/kafkat/command/clean_indexes.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Kafkat
   module Command
     class CleanIndexes < Base
@@ -8,16 +9,16 @@ module Kafkat
 
       def run
         print "This operation will remove any untruncated index files.\n"
-        return unless ask("Proceed (y/n)?")
+        return unless ask('Proceed (y/n)?')
 
         begin
           print "\nStarted.\n"
           count = kafka_logs.clean_indexes!
           print "\nDone (#{count} index file(s) removed).\n"
-        rescue Interface::KafkaLogs::NoLogsError => e
+        rescue Interface::KafkaLogs::NoLogsError
           print "ERROR: Kakfa log directory doesn't exist.\n"
           exit 1
-        rescue Interface::KafkaLogs::KafkaRunningError => e
+        rescue Interface::KafkaLogs::KafkaRunningError
           print "ERROR: Kafka is still running.\n"
           exit 1
         rescue => e

--- a/lib/kafkat/command/cluster_restart.rb
+++ b/lib/kafkat/command/cluster_restart.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafkat
   module Command
     class ClusterRestart < Base
@@ -198,7 +200,7 @@ module Kafkat
         raise UnknownBrokerError, "Unknown broker #{broker_id}" unless session.broker_states.key?(broker_id)
 
         partitions.find_all { |partition| partition.leader == broker_id }
-                  .reduce(0) do |cost, partition|
+          .reduce(0) do |cost, partition|
           cost += partition.replicas.length
           cost -= partition.replicas.find_all { |replica| session.restarted?(replica) }.size
           cost
@@ -207,11 +209,11 @@ module Kafkat
     end
 
     class Session
-      SESSION_PATH = '~/kafkat_cluster_restart_session.json'.freeze
-      STATE_RESTARTED = 'restarted'.freeze # use String instead of Symbol to facilitate JSON ser/deser
-      STATE_NOT_RESTARTED = 'not_restarted'.freeze
-      STATE_PENDING = 'pending'.freeze
-      STATES = [STATE_NOT_RESTARTED, STATE_RESTARTED, STATE_PENDING].freeze
+      SESSION_PATH = '~/kafkat_cluster_restart_session.json'
+      STATE_RESTARTED = 'restarted' # use String instead of Symbol to facilitate JSON ser/deser
+      STATE_NOT_RESTARTED = 'not_restarted'
+      STATE_PENDING = 'pending'
+      STATES = [STATE_NOT_RESTARTED, STATE_RESTARTED, STATE_PENDING]
 
       class NotFoundError < StandardError; end
       class ParseError < StandardError; end

--- a/lib/kafkat/command/controller.rb
+++ b/lib/kafkat/command/controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Kafkat
   module Command
     class Controller < Base
@@ -7,7 +8,7 @@ module Kafkat
             'Print the current controller.'
 
       def run
-        c = zookeeper.get_controller
+        c = zookeeper.controller
         print "The current controller is '#{c.id}' (#{c.host}:#{c.port}).\n"
       rescue Interface::Zookeeper::NotFoundError
         print "ERROR: Couldn't determine the current controller.\n"

--- a/lib/kafkat/command/elect_leaders.rb
+++ b/lib/kafkat/command/elect_leaders.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Kafkat
   module Command
     class ElectLeaders < Base
@@ -10,12 +11,12 @@ module Kafkat
         topic_name = ARGV[0] && ARGV.shift
         topic_names = topic_name && [topic_name]
 
-        topics = zookeeper.get_topics(topic_names)
+        topics = zookeeper.topics(topic_names)
         partitions = topics.values.map(&:partitions).flatten
 
-        topics_s = topic_name ? "'#{topic_name}'" : "all topics"
+        topics_s = topic_name ? "'#{topic_name}'" : 'all topics'
         print "This operation elects the preferred replicas for #{topics_s}.\n"
-        return unless agree("Proceed (y/n)?")
+        return unless agree('Proceed (y/n)?')
 
         result = nil
         begin

--- a/lib/kafkat/command/partitions.rb
+++ b/lib/kafkat/command/partitions.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Kafkat
   module Command
     class Describe < Base
@@ -11,19 +12,19 @@ module Kafkat
             'Print partitions by topic (only unavailable).'
 
       def run
-        topic_name = ARGV.shift unless ARGV[0] && ARGV[0].start_with?('--')
+        topic_name = ARGV.shift unless ARGV[0]&.start_with?('--')
         topic_names = topic_name && [topic_name]
 
         @options = Optimist.options do
-          opt :under_replicated, "only under-replicated"
-          opt :unavailable, "only unavailable"
+          opt :under_replicated, 'only under-replicated'
+          opt :unavailable, 'only unavailable'
         end
 
-        brokers = zookeeper.get_brokers
-        topics = zookeeper.get_topics(topic_names)
+        brokers = zookeeper.brokers
+        topics = zookeeper.topics(topic_names)
 
         print_partition_header
-        topics.each do |name, t|
+        topics.each do |_, t|
           t.partitions.each do |p|
             print_partition(p) if selected?(p, brokers)
           end

--- a/lib/kafkat/command/resign_rewrite.rb
+++ b/lib/kafkat/command/resign_rewrite.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Kafkat
   module Command
     class ResignForce < Base
@@ -12,21 +13,22 @@ module Kafkat
       def run
         broker_id = ARGV[0] && ARGV.shift.to_i
         if broker_id.nil?
-          puts "You must specify a broker ID."
+          puts 'You must specify a broker ID.'
           exit 1
         end
 
         opts = Optimist.options do
-          opt :force, "force"
+          opt :force, 'force'
         end
 
         print "This operation rewrites leaderships in ZK to exclude broker '#{broker_id}'.\n"
         print "WARNING: This is a last resort. Try the 'shutdown' command first!\n\n".red
 
-        return unless agree("Proceed (y/n)?")
+        return unless agree('Proceed (y/n)?')
 
-        brokers = zookeeper.get_brokers
-        topics = zookeeper.get_topics
+        # Unused assignment.  Commenting for now, removing later.
+        # brokers = zookeeper.brokers
+        topics = zookeeper.topics
         force = opts[:force]
 
         ops = {}
@@ -64,7 +66,7 @@ module Kafkat
               zookeeper.write_leader(p, lid)
             end
           end
-        rescue Interface::Zookeeper::WriteConflictError => e
+        rescue Interface::Zookeeper::WriteConflictError
           print "Failed to update leaderships in ZK. Try re-running.\n\n"
           exit 1
         end

--- a/lib/kafkat/command/shutdown.rb
+++ b/lib/kafkat/command/shutdown.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Kafkat
   module Command
     class Resign < Base
@@ -9,12 +10,12 @@ module Kafkat
       def run
         broker_id = ARGV[0] && ARGV.shift.to_i
         if broker_id.nil?
-          puts "You must specify a broker ID."
+          puts 'You must specify a broker ID.'
           exit 1
         end
 
         print "This operation gracefully removes leaderships from broker '#{broker_id}'.\n"
-        return unless agree("Proceed (y/n)?")
+        return unless agree('Proceed (y/n)?')
 
         result = nil
         begin

--- a/lib/kafkat/command/topics.rb
+++ b/lib/kafkat/command/topics.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Kafkat
   module Command
     class Topics < Base
@@ -7,7 +8,7 @@ module Kafkat
             'Print all topics.'
 
       def run
-        topic_names = zookeeper.get_topic_names
+        topic_names = zookeeper.topic_names
 
         topic_names.each { |name| print_topic_name(name) }
       end

--- a/lib/kafkat/command/verify_replicas.rb
+++ b/lib/kafkat/command/verify_replicas.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Kafkat
   module Command
     class VerifyReplicas < Base
@@ -8,10 +9,10 @@ module Kafkat
 
       def run
         opts = Optimist.options do
-          opt :topics, "topic names", type: :string
-          opt :broker, "broker ID", type: :string
-          opt :print_details, "show replica size of mismatched partitions", :default => false
-          opt :print_summary, "show summary of mismatched partitions", :default => false
+          opt :topics, 'topic names', type: :string
+          opt :broker, 'broker ID', type: :string
+          opt :print_details, 'show replica size of mismatched partitions', default: false
+          opt :print_summary, 'show summary of mismatched partitions', default: false
         end
 
         topic_names = opts[:topics]
@@ -20,10 +21,10 @@ module Kafkat
 
         if topic_names
           topics_list = topic_names.split(',')
-          topics = zookeeper.get_topics(topics_list)
+          topics = zookeeper.topics(topics_list)
         end
-        topics ||= zookeeper.get_topics
-        broker = opts[:broker] && opts[:broker].to_i
+        topics ||= zookeeper.topics
+        broker = opts[:broker]&.to_i
 
         partition_replica_size, partition_replica_size_stat = verify_replicas(broker, topics)
 
@@ -49,16 +50,15 @@ module Kafkat
 
             partition_replica_size[t.name][p.id] = replica_size
           end
-
         end
 
-        return partition_replica_size, partition_replica_size_stat
+        [partition_replica_size, partition_replica_size_stat]
       end
 
       def print_mismatched_partitions(partition_replica_size, partition_replica_size_stat, print_details, print_summary)
         topic_column_width = partition_replica_size.keys.max_by(&:length).length
         if print_details
-          printf "%-#{topic_column_width}s %-10s %-15s %-20s\n", "topic", "partition", "replica_size", "replication_factor"
+          printf "%-#{topic_column_width}s %-10s %-15s %-20s\n", 'topic', 'partition', 'replica_size', 'replication_factor'
 
           partition_replica_size.each do |topic_name, partition|
             replication_factor = partition_replica_size_stat[topic_name].key(partition_replica_size_stat[topic_name].values.max)
@@ -72,17 +72,17 @@ module Kafkat
         end
 
         if print_summary
-          printf "%-#{topic_column_width}s %-15s %-10s %-15s %-20s\n", "topic", "replica_size", "count", "percentage", "replication_factor"
+          printf "%-#{topic_column_width}s %-15s %-10s %-15s %-20s\n", 'topic', 'replica_size', 'count', 'percentage', 'replication_factor'
           partition_replica_size_stat.each do |topic_name, partition|
-            if partition.values.size > 1
-              replication_factor = partition_replica_size_stat[topic_name].key(partition_replica_size_stat[topic_name].values.max)
-              num_partitions = 0.0
-              partition.each { |key, value| num_partitions += value }
+            next unless partition.values.size > 1
 
-              partition.each do |replica_size, cnt|
-                printf "%-#{topic_column_width}s %-15d %-10d %-15d %-20d\n", topic_name, replica_size, cnt, (cnt * 100 /num_partitions)
-                                                                                           .to_i, replication_factor
-              end
+            replication_factor = partition_replica_size_stat[topic_name].key(partition_replica_size_stat[topic_name].values.max)
+            num_partitions = 0.0
+            partition.each { |_, value| num_partitions += value }
+
+            partition.each do |replica_size, cnt|
+              printf "%-#{topic_column_width}s %-15d %-10d %-15d %-20d\n", topic_name, replica_size, cnt, (cnt * 100 / num_partitions)
+                .to_i, replication_factor
             end
           end
         end

--- a/lib/kafkat/config.rb
+++ b/lib/kafkat/config.rb
@@ -2,8 +2,8 @@ module Kafkat
   class Config
     CONFIG_PATHS = [
       '~/.kafkatcfg',
-      '/etc/kafkatcfg'
-    ]
+      '/etc/kafkatcfg',
+    ].freeze
 
     class NotFoundError < StandardError; end
     class ParseError < StandardError; end
@@ -28,8 +28,7 @@ module Kafkat
       raise e if e && string.nil?
 
       json = JSON.parse(string)
-      self.new(json)
-
+      new(json)
     rescue Errno::ENOENT
       raise NotFoundError
     rescue JSON::JSONError

--- a/lib/kafkat/config.rb
+++ b/lib/kafkat/config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafkat
   class Config
     CONFIG_PATHS = [
@@ -17,12 +19,9 @@ module Kafkat
       e = nil
 
       CONFIG_PATHS.each do |rel_path|
-        begin
-          path = File.expand_path(rel_path)
-          string = File.read(path)
-          break
-        rescue => e
-        end
+        path = File.expand_path(rel_path)
+        string = File.read(path)
+        break
       end
 
       raise e if e && string.nil?

--- a/lib/kafkat/interface.rb
+++ b/lib/kafkat/interface.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'kafkat/interface/admin'
 require 'kafkat/interface/kafka_logs'
 require 'kafkat/interface/zookeeper'

--- a/lib/kafkat/interface/admin.rb
+++ b/lib/kafkat/interface/admin.rb
@@ -1,4 +1,6 @@
+# frozen_string_literal: true
 require 'tempfile'
+require 'English'
 
 module Kafkat
   module Interface
@@ -20,17 +22,17 @@ module Kafkat
         partitions.each do |p|
           json_partitions << {
             'topic' => p.topic_name,
-            'partition' => p.id
+            'partition' => p.id,
           }
         end
 
-        json = {'partitions' => json_partitions}
+        json = { 'partitions' => json_partitions }
         file.write(JSON.dump(json))
         file.close
 
         run_tool(
           'kafka-preferred-replica-election',
-            '--path-to-json-file', file.path
+          '--path-to-json-file', file.path
         )
       ensure
         file.unlink
@@ -44,13 +46,13 @@ module Kafkat
           json_partitions << {
             'topic' => a.topic_name,
             'partition' => a.partition_id,
-            'replicas' => a.replicas
+            'replicas' => a.replicas,
           }
         end
 
         json = {
           'partitions' => json_partitions,
-          'version' => 1
+          'version' => 1,
         }
 
         file.write(JSON.dump(json))
@@ -58,22 +60,22 @@ module Kafkat
 
         run_tool(
           'kafka-reassign-partitions',
-            '--execute',
-            '--reassignment-json-file', file.path
+          '--execute',
+          '--reassignment-json-file', file.path
         )
       ensure
         file.unlink
       end
 
-      def shutdown!(broker_id, options={})
+      def shutdown!(broker_id, options = {})
         args = ['--broker', broker_id]
         args += ['--num.retries', options[:retries]] if options[:retries]
         args += ['--retry.interval.ms', option[:interval]] if options[:interval]
 
         run_tool(
           'kafka-run-class',
-            'kafka.admin.ShutdownBroker',
-            *args
+          'kafka.admin.ShutdownBroker',
+          *args
         )
       end
 
@@ -81,8 +83,9 @@ module Kafkat
         path = File.join(kafka_path, "bin/#{name}.sh")
         args += ['--zookeeper', "\"#{zk_path}\""]
         args_string = args.join(' ')
-        result = `#{path} #{args_string}`
-        raise ExecutionFailedError if $?.to_i > 0
+        result = %(#{path} #{args_string})
+        raise ExecutionFailedError if $CHILD_STATUS.to_i > 0
+
         result
       end
     end

--- a/lib/kafkat/interface/kafka_logs.rb
+++ b/lib/kafkat/interface/kafka_logs.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Kafkat
   module Interface
     class KafkaLogs
@@ -35,13 +36,14 @@ module Kafkat
       private
 
       def check_exists
-        raise NoLogsError unless File.exists?(log_path)
+        raise NoLogsError unless File.exist?(log_path)
       end
 
       def lock_for_write
         File.open(lockfile_path, File::CREAT) do |lockfile|
           locked = lockfile.flock(File::LOCK_EX | File::LOCK_NB)
           raise KafkaRunningError unless locked
+
           yield
         end
       end

--- a/lib/kafkat/utility.rb
+++ b/lib/kafkat/utility.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'kafkat/utility/formatting'
 require 'kafkat/utility/command_io'
 require 'kafkat/utility/logging'

--- a/lib/kafkat/utility.rb
+++ b/lib/kafkat/utility.rb
@@ -1,4 +1,3 @@
 require 'kafkat/utility/formatting'
 require 'kafkat/utility/command_io'
 require 'kafkat/utility/logging'
-

--- a/lib/kafkat/utility/command_io.rb
+++ b/lib/kafkat/utility/command_io.rb
@@ -6,7 +6,7 @@ module Kafkat
       assignments.each { |a| print_assignment(a) }
       print "\n"
 
-      return unless agree("Proceed (y/n)?")
+      return unless agree('Proceed (y/n)?')
 
       result = nil
       begin

--- a/lib/kafkat/utility/command_io.rb
+++ b/lib/kafkat/utility/command_io.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafkat
   module CommandIO
     def prompt_and_execute_assignments(assignments)

--- a/lib/kafkat/utility/formatting.rb
+++ b/lib/kafkat/utility/formatting.rb
@@ -1,6 +1,6 @@
 module Kafkat
   module Formatting
-    def justify(field, width=2)
+    def justify(field, width = 2)
       field = field.to_s
       count = [width - (field.length / 8), 1].max
       field + "\t" * count

--- a/lib/kafkat/utility/formatting.rb
+++ b/lib/kafkat/utility/formatting.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafkat
   module Formatting
     def justify(field, width = 2)

--- a/lib/kafkat/utility/logging.rb
+++ b/lib/kafkat/utility/logging.rb
@@ -1,7 +1,7 @@
 module Kafkat
   module Logging
-   def print_err(message)
-    STDERR.print message
-   end
+    def print_err(message)
+      STDERR.print message
+    end
   end
 end

--- a/lib/kafkat/utility/logging.rb
+++ b/lib/kafkat/utility/logging.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafkat
   module Logging
     def print_err(message)

--- a/lib/kafkat/version.rb
+++ b/lib/kafkat/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafkat
-  VERSION = '0.3.0'.freeze
+  VERSION = '0.3.0'
 end

--- a/lib/kafkat/version.rb
+++ b/lib/kafkat/version.rb
@@ -1,3 +1,3 @@
 module Kafkat
-  VERSION = '0.3.0'
+  VERSION = '0.3.0'.freeze
 end

--- a/spec/factories/topic.rb
+++ b/spec/factories/topic.rb
@@ -1,7 +1,7 @@
 module Kafkat
-  FactoryGirl.define do
-    factory :topic, class:Topic do
-      name "topic_name"
+  FactoryBot.define do
+    factory :topic, class: Topic do
+      name { 'topic_name' }
 
       factory :topic_with_one_empty_broker do
         partitions {[Partition.new(name, 0, [0], 0, [0]),
@@ -36,17 +36,17 @@ module Kafkat
       end
 
       factory :topic_rep_factor_three_with_four_replicas_in_partition1 do
-        name "topic_name1"
-        partitions  [Partition.new("topic_name1", 0, [0, 1, 2], 0, [0]),
-                     Partition.new("topic_name1", 1, [0, 1, 2, 6], 1, [1]),
-                     Partition.new("topic_name1", 2, [0, 1, 2], 2, [2])]
+        name { 'topic_name1' }
+        partitions { [Partition.new('topic_name1', 0, [0, 1, 2], 0, [0]),
+                     Partition.new('topic_name1', 1, [0, 1, 2, 6], 1, [1]),
+                     Partition.new('topic_name1', 2, [0, 1, 2], 2, [2])] }
       end
 
       factory :topic2_rep_factor_three do
-        name "topic_name2"
-        partitions [Partition.new("topic_name2", 0, [3, 4, 5], 0, [0]),
-                     Partition.new("topic_name2", 1, [3, 4, 5], 0, [0]),
-                     Partition.new("topic_name2", 2, [3, 4, 5], 1, [1])]
+        name { 'topic_name2' }
+        partitions { [Partition.new('topic_name2', 0, [3, 4, 5], 0, [0]),
+                     Partition.new('topic_name2', 1, [3, 4, 5], 0, [0]),
+                     Partition.new('topic_name2', 2, [3, 4, 5], 1, [1])] }
       end
     end
   end

--- a/spec/lib/kafkat/command/cluster_restart_spec.rb
+++ b/spec/lib/kafkat/command/cluster_restart_spec.rb
@@ -20,7 +20,7 @@ module Kafkat
 
         describe '#allBrokersRestarted?' do
           context 'when some brokers have not been restarted' do
-            let (:session) {
+            let(:session) {
               Session.new('broker_states' => {'1' => Session::STATE_NOT_RESTARTED, '2' => Session::STATE_RESTARTED})
             }
 
@@ -30,7 +30,7 @@ module Kafkat
           end
 
           context 'when all brokers have been restarted' do
-            let (:session) {
+            let(:session) {
               Session.new('broker_states' => {'1' => Session::STATE_RESTARTED, '2' => Session::STATE_RESTARTED})
             }
 
@@ -41,7 +41,7 @@ module Kafkat
         end
 
         describe '#update_states!' do
-          let (:session) {
+          let(:session) {
             Session.new('broker_states' => {'1' => Session::STATE_NOT_RESTARTED, '2' => Session::STATE_RESTARTED})
           }
 
@@ -66,7 +66,7 @@ module Kafkat
         let(:p1) { Partition.new('topic1', 'p1', ['1', '2', '3'], '1', 1) }
         let(:p2) { Partition.new('topic1', 'p2', ['1', '2', '3'], '2', 1) }
         let(:p3) { Partition.new('topic1', 'p3', ['2', '3', '4'], '3', 1) }
-        let (:topics) {
+        let(:topics) {
           {
               'topic1' => Topic.new('topic1', [p1, p2, p3])
           }
@@ -81,9 +81,9 @@ module Kafkat
           let(:next_command) { Subcommands::Next.new({}) }
 
           it 'execute next with 4 brokers and 3 partitions' do
-            allow(zookeeper).to receive(:get_broker_ids).and_return(broker_ids)
+            allow(zookeeper).to receive(:broker_ids).and_return(broker_ids)
             allow(zookeeper).to receive(:get_broker).and_return(broker_4)
-            allow(zookeeper).to receive(:get_topics).and_return(topics)
+            allow(zookeeper).to receive(:topics).and_return(topics)
             allow(Session).to receive(:exists?).and_return(true)
             allow(Session).to receive(:load!).and_return(session)
             allow(session).to receive(:save!)
@@ -121,7 +121,7 @@ module Kafkat
         let(:p1) { Partition.new('topic1', 'p1', ['1', '2', '3'], '1', 1) }
         let(:p2) { Partition.new('topic1', 'p2', ['1', '2', '3'], '2', 1) }
         let(:p3) { Partition.new('topic1', 'p3', ['2', '3', '4'], '3', 1) }
-        let (:topics) {
+        let(:topics) {
           {
               'topic1' => Topic.new('topic1', [p1, p2, p3])
           }

--- a/spec/lib/kafkat/command/drain_spec.rb
+++ b/spec/lib/kafkat/command/drain_spec.rb
@@ -7,7 +7,7 @@ module Kafkat
     let(:destination_broker_ids) { [1, 2] }
 
     context 'three nodes with replication factor 1' do
-      let(:topic_rep_factor_one) { FactoryGirl.build(:topic_rep_factor_one) }
+      let(:topic_rep_factor_one) { FactoryBot.build(:topic_rep_factor_one) }
 
       it 'should put replicas to broker with lowest number of replicas' do
         assignments = drain.generate_assignments(broker_id,
@@ -20,7 +20,7 @@ module Kafkat
     end
 
     context 'three nodes with replication factor 2' do
-      let(:topic_rep_factor_two) { FactoryGirl.build(:topic_rep_factor_two) }
+      let(:topic_rep_factor_two) { FactoryBot.build(:topic_rep_factor_two) }
       it 'should put replicas to broker with lowest number of replicas' do
         assignments = drain.generate_assignments(broker_id,
                                                  {"topic_name" => topic_rep_factor_two},
@@ -34,7 +34,7 @@ module Kafkat
     end
 
     context 'not enough brokers to keep all replicas' do
-      let(:topic_rep_factor_three) { FactoryGirl.build(:topic_rep_factor_three) }
+      let(:topic_rep_factor_three) { FactoryBot.build(:topic_rep_factor_three) }
 
       it 'should raise SystemExit' do
         expect do
@@ -46,7 +46,7 @@ module Kafkat
     end
 
     context 'one destination broker is empty' do
-      let(:topic_with_one_empty_broker) { FactoryGirl.build(:topic_with_one_empty_broker) }
+      let(:topic_with_one_empty_broker) { FactoryBot.build(:topic_with_one_empty_broker) }
       it 'should not raise exception' do
         expect do
           drain.generate_assignments(broker_id,

--- a/spec/lib/kafkat/command/verify_replicas_spec.rb
+++ b/spec/lib/kafkat/command/verify_replicas_spec.rb
@@ -6,8 +6,8 @@ module Kafkat
 
     context 'two topics with replication factor 3' do
       let(:topic_rep_factor_three_with_four_replicas_in_partition1) {
-        FactoryGirl.build(:topic_rep_factor_three_with_four_replicas_in_partition1) }
-      let(:topic2_rep_factor_three) { FactoryGirl.build(:topic2_rep_factor_three) }
+        FactoryBot.build(:topic_rep_factor_three_with_four_replicas_in_partition1) }
+      let(:topic2_rep_factor_three) { FactoryBot.build(:topic2_rep_factor_three) }
 
       it 'should return empty mismatched partitions for all brokers' do
         partition_replica_size, partition_replica_size_stat = verify_replicas.verify_replicas(nil,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,7 +20,7 @@ if ENV['COVERAGE']
     require 'simplecov'
 end
 require 'kafkat'
-require 'factory_girl'
+require 'factory_bot'
 require 'rspec/collection_matchers'
 
 require_relative '../spec/factories/topic'
@@ -49,7 +49,7 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
-  config.include FactoryGirl::Syntax::Methods
+  config.include FactoryBot::Syntax::Methods
 
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.


### PR DESCRIPTION
Based the rubocop configuration off of the shopify ruby styleguide which
is a pretty nice starting point and added some customizations that fit
well with the existing project.  Significant work was done to bring the
code base into compliance with the style guide.  Standardized file
naming with snake case instead a mix of snake and dashes.  In addition,
factory_girl was replaced by factory_bot and the factories updated.

Closes #2 