### PR TITLE
Reduce config load complexity

### DIFF
--- a/lib/kafkat/cli.rb
+++ b/lib/kafkat/cli.rb
@@ -44,6 +44,8 @@ module Kafkat
       subcommand.print_error_and_exit("Could not parse configuration file: #{e}", 1)
     rescue Mixlib::Config::UnknownConfigOptionError => e
       subcommand.print_error_and_exit("Invalid configuration file: #{e}", 1)
+    rescue Kafkat::Config::ParserError => e
+      print_error_and_exit("An error occured: #{e}", 1)
     rescue OptionParser::InvalidOption
       subcommand.print_help_and_exit(1, category: category_name)
     rescue OptionParser::MissingArgument

--- a/lib/kafkat/config.rb
+++ b/lib/kafkat/config.rb
@@ -13,33 +13,36 @@ module Kafkat
     default :kafka_path, '.'
 
     PATHS = [
-      '.kafkat.json',
-      '.kafkat.yml',
-      '~/.kafkat.json',
-      '~/.kafkat.yml',
       '/etc/kafkat/config.json',
-      '/etc/kafkat/config.yml',
+      '~/.kafkat.json',
+      '.kafkat.json',
     ].freeze
+
+    def self.reset!
+      # From Mixlib::Config
+      reset
+      # Reload
+      @loaded = false
+    end
 
     def self.load!
       return true if @loaded
 
-      PATHS.each do |rel_path|
-        path = File.expand_path(rel_path)
-        next unless File.exist?(path)
-        load_file!(path)
-        @loaded = true
-        break
-      end
-      raise NotFoundError unless @loaded
-    rescue Errno::ENOENT
-      raise NotFoundError
-    end
+      # Established order of precidence for right now just take the
+      # last one, but in the future we will iterate through all of
+      # them allowing overrides the closer you get to the working dir.
+      configs = PATHS
+        .map { |f| File.expand_path(f) }
+        .select { |f| File.exist?(f) }
 
-    def self.load_file!(path)
+      raise NotFoundError if configs.empty?
+
+      path = File.expand_path(configs.last)
       from_file(path)
-    rescue Errno::ENOENT
-      raise NotFoundError
+      @loaded = true
+
+    rescue Errno::EACCES
+      raise ParseError, 'Permission denied'
     end
   end
 end

--- a/spec/lib/kafkat/config_spec.rb
+++ b/spec/lib/kafkat/config_spec.rb
@@ -1,0 +1,98 @@
+require 'json'
+
+describe Kafkat::Config do
+  describe '.load!' do
+    before(:each) do
+      Kafkat::Config.reset!
+    end
+
+    context 'invalid config files' do
+      it 'raises an error if no files are present' do
+        allow(File).to receive(:exist?).and_return(false)
+        expect { Kafkat::Config.load! }.to raise_error(Kafkat::Config::NotFoundError)
+      end
+
+      it 'raises an error if incorrect permissions' do
+        allow(File).to receive(:exist?).and_return(true)
+        allow(IO).to receive(:read).and_raise(Errno::EACCES)
+        expect { Kafkat::Config.load! }.to raise_error(Kafkat::Config::ParseError)
+      end
+    end
+
+    context 'config file precedence' do
+      let(:etc_kafkat_config) do
+        JSON.generate({
+          kafka_path: '/opt/kafka-1',
+          zk_path: 'localhost:2181',
+          log_path: '/kafka-1',
+        })
+      end
+      let(:home_kafka) do
+        JSON.generate({
+          kafka_path: '/opt/kafka-2',
+          zk_path: 'localhost:2182',
+          log_path: '/kafka-2',
+        })
+      end
+      let(:cwd_kafka) do
+        JSON.generate({
+          kafka_path: '/opt/kafka-3',
+          zk_path: 'localhost:2183',
+          log_path: '/kafka-3',
+        })
+      end
+
+      it 'loads /etc/kafkat/config.json' do
+        allow(File).to receive(:exist?).and_return(false)
+        allow(File).to receive(:exist?).with('/etc/kafkat/config.json').and_return(true)
+        # Mixlib::Config uses IO.read
+        allow(IO).to receive(:read).and_raise(Errno::EACCES)
+        allow(IO).to receive(:read).with('/etc/kafkat/config.json').and_return(etc_kafkat_config)
+
+        Kafkat::Config.load!
+        expect(Kafkat::Config.kafka_path).to eq('/opt/kafka-1')
+        expect(Kafkat::Config.zk_path).to eq('localhost:2181')
+        expect(Kafkat::Config.log_path).to eq('/kafka-1')
+      end
+
+      it 'loads ~/.kafkat.json' do
+        allow(File).to receive(:exist?).and_return(false)
+        allow(File).to receive(:exist?).with(File.expand_path('~/.kafkat.json')).and_return(true)
+        # Mixlib::Config uses IO.read
+        allow(IO).to receive(:read).and_raise(Errno::EACCES)
+        allow(IO).to receive(:read).with(File.expand_path('~/.kafkat.json')).and_return(home_kafka)
+
+        Kafkat::Config.load!
+        expect(Kafkat::Config.kafka_path).to eq('/opt/kafka-2')
+        expect(Kafkat::Config.zk_path).to eq('localhost:2182')
+        expect(Kafkat::Config.log_path).to eq('/kafka-2')
+      end
+
+      it 'loads .kafkat.json' do
+        allow(File).to receive(:exist?).and_return(false)
+        allow(File).to receive(:exist?).with(File.expand_path('.kafkat.json')).and_return(true)
+        # Mixlib::Config uses IO.read
+        allow(IO).to receive(:read).and_raise(Errno::EACCES)
+        allow(IO).to receive(:read).with(File.expand_path('.kafkat.json')).and_return(cwd_kafka)
+
+        Kafkat::Config.load!
+        expect(Kafkat::Config.kafka_path).to eq('/opt/kafka-3')
+        expect(Kafkat::Config.zk_path).to eq('localhost:2183')
+        expect(Kafkat::Config.log_path).to eq('/kafka-3')
+      end
+
+      it 'loads .kafkat.json on fallthrough' do
+        allow(File).to receive(:exist?).and_return(true)
+        allow(File).to receive(:exist?).with(File.expand_path('.kafkat.json')).and_return(true)
+        # Mixlib::Config uses IO.read
+        allow(IO).to receive(:read).and_return(nil)
+        allow(IO).to receive(:read).with(File.expand_path('.kafkat.json')).and_return(cwd_kafka)
+
+        Kafkat::Config.load!
+        expect(Kafkat::Config.kafka_path).to eq('/opt/kafka-3')
+        expect(Kafkat::Config.zk_path).to eq('localhost:2183')
+        expect(Kafkat::Config.log_path).to eq('/kafka-3')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Some minor cleanup of the config module.  The class cleanup expands the
file paths, and selects the files that exist into a new array.  For
right now we just take the last one in the array that exists (the array
is ordered by precedence).  Though we just take the last right now, this
sets everything up to do a merge of options as we run down the list.
I'm not sure that we need this, but it will be ok to have it in place
just in case.

Added testing around thr config module.