### PR TITLE
Fix issue 42

### DIFF
--- a/lib/kafkat/cli.rb
+++ b/lib/kafkat/cli.rb
@@ -29,7 +29,7 @@ module Kafkat
 
       # Load configuration
       if subcommand.config[:config_file]
-        Config.load_file!(config[:config_file])
+        Config.load!(paths: [subcommand.config[:config_file]])
       else
         Config.load!
       end
@@ -44,8 +44,10 @@ module Kafkat
       subcommand.print_error_and_exit("Could not parse configuration file: #{e}", 1)
     rescue Mixlib::Config::UnknownConfigOptionError => e
       subcommand.print_error_and_exit("Invalid configuration file: #{e}", 1)
-    rescue Kafkat::Config::ParserError => e
-      print_error_and_exit("An error occured: #{e}", 1)
+    rescue Kafkat::Config::ParseError => e
+      subcommand.print_error_and_exit(e, 1)
+    rescue Kafkat::Config::NotFoundError => e
+      subcommand.print_error_and_exit(e, 1)
     rescue OptionParser::InvalidOption
       subcommand.print_help_and_exit(1, category: category_name)
     rescue OptionParser::MissingArgument

--- a/lib/kafkat/config.rb
+++ b/lib/kafkat/config.rb
@@ -26,17 +26,18 @@ module Kafkat
       @loaded = false
     end
 
-    def self.load!
+    def self.load!(paths: [])
       return true if @loaded
 
+      paths = PATHS if paths.empty?
       # Established order of precidence for right now just take the
       # last one, but in the future we will iterate through all of
       # them allowing overrides the closer you get to the working dir.
-      configs = PATHS
+      configs = paths
         .map { |f| File.expand_path(f) }
         .select { |f| File.exist?(f) }
 
-      raise NotFoundError if configs.empty?
+      raise NotFoundError, 'There were no configuation files found.' if configs.empty?
 
       path = File.expand_path(configs.last)
       from_file(path)

--- a/spec/lib/kafkat/config_spec.rb
+++ b/spec/lib/kafkat/config_spec.rb
@@ -41,6 +41,13 @@ describe Kafkat::Config do
           log_path: '/kafka-3',
         })
       end
+      let(:custom_kafka) do
+        JSON.generate({
+          kafka_path: '/opt/kafka-4',
+          zk_path: 'localhost:2184',
+          log_path: '/kafka-4',
+        })
+      end
 
       it 'loads /etc/kafkat/config.json' do
         allow(File).to receive(:exist?).and_return(false)
@@ -92,6 +99,18 @@ describe Kafkat::Config do
         expect(Kafkat::Config.kafka_path).to eq('/opt/kafka-3')
         expect(Kafkat::Config.zk_path).to eq('localhost:2183')
         expect(Kafkat::Config.log_path).to eq('/kafka-3')
+      end
+
+      it 'loads a custom config file' do
+        allow(File).to receive(:exist?).and_return(true)
+        allow(File).to receive(:exist?).with(File.expand_path('.custom.json')).and_return(true)
+        allow(IO).to receive(:read).and_return(nil)
+        allow(IO).to receive(:read).with(File.expand_path('.custom.json')).and_return(custom_kafka)
+
+        Kafkat::Config.load!(paths: ['.custom.json'])
+        expect(Kafkat::Config.kafka_path).to eq('/opt/kafka-4')
+        expect(Kafkat::Config.zk_path).to eq('localhost:2184')
+        expect(Kafkat::Config.log_path).to eq('/kafka-4')
       end
     end
   end


### PR DESCRIPTION
The recent update of config.rb to reduce complexity in the load! method
introduced a significant error in that it removed the load_file! method
that the cli used to load any custom files that were specified on the
command line.  Instead of adding the method again, I added an optional
paths argument to the load! method.  Unit tests were added around that
specific feature so it won't happen again, but we really need some
integration tests to ensure that the run command works in every senario.

While I was working through that I noticed that there was another
oversight in that we were no longer catching the NotFoundException and
that it was never actually giving a message for the cli to display.
That specific issue has been addressed as well.

Fixes #42 